### PR TITLE
api: update - Update clear users job

### DIFF
--- a/api/config/app.php
+++ b/api/config/app.php
@@ -178,8 +178,8 @@ return [
     | deleted. It also defines, after how many days after the user has been
     | created, not verified accounts should be deleted.
     |
-    | 'delete_inactive_after' is the time in months after inactive users should
-    | be deleted.
+    | 'delete_inactive_after' is the time in months after inactive/not updated
+    | users should be deleted. (Beginning at the end of the year)
     | 'delete_unverified_after' is the time in days, after a user with an un-
     | verified email should be deleted.
     |


### PR DESCRIPTION
The reason why it is configurable for how long users should be stored, is that you have to keep bills etc. for a longer period because of law. In some countries those periods begin at the end of the current year. So in some cases you have to store customer data for 10 years and some more months. To gurantee that those data won't be deleted too early, we just remove them at the end of the year. However the job will still run every day to make sure that users with unverified email will still be deleted.