### PR TITLE
User deletion management

### DIFF
--- a/api/app/Console/Kernel.php
+++ b/api/app/Console/Kernel.php
@@ -32,18 +32,31 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
 
-        // Artisan commands
+        /**
+         * Artisan commands
+         */
+
         $schedule->command('passport:purge')->daily();
 
-        // Jobs
+        /**
+         * Jobs
+         */
+
+        // Auth
         $schedule->job((new \App\Jobs\Auth\ClearEmailChanges())->onConnection('sync')->onQueue('job'))
             ->daily();
         $schedule->job((new \App\Jobs\Auth\ClearPasswordResets())->onConnection('sync')->onQueue('job'))
             ->daily();
         $schedule->job((new \App\Jobs\Auth\ClearRestoreUsers())->onConnection('sync')->onQueue('job'))
             ->daily();
+
+        // User
         $schedule->job((new \App\Jobs\User\ClearUsers())->onConnection('sync')->onQueue('job'))
             ->daily();
+        $schedule->job((new \App\Jobs\User\DeleteInactiveUsers())->onConnection('sync')->onQueue('job'))
+            ->daily();
+        $schedule->job((new \App\Jobs\User\DeleteUnverifiedUsers())->onConnection('sync')
+            ->onQueue('job'))->daily();
 
     }
 

--- a/api/app/Jobs/User/DeleteInactiveUsers.php
+++ b/api/app/Jobs/User/DeleteInactiveUsers.php
@@ -7,28 +7,35 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
 
+/**
+ * Class DeleteInactiveUsers
+ * @package App\Jobs\User
+ */
 class DeleteInactiveUsers implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Execute the job.
      *
+     * @param  \App\Models\User $users
      * @return void
      */
-    public function handle()
+    public function handle(\App\Models\User $users)
     {
-        //
+        // TODO Should not soft deleted users that have valid tickets or invoices assigned.
+
+        // Soft delete users that haven't been updated (inactive) for x months, beginning at the end of the year.
+        // Admin users will be ignored and not soft deleted automatically.
+        $users = $users->where('role_id', '!=', adminRole())
+            ->where('updated_at', '<', Carbon::now()->subMonths(deleteInactiveUsers())->startOfYear())
+            ->get();
+
+        // Must iterate over users to call delete event which will send the notification.
+        foreach ($users as $user) {
+            $user->delete();
+        }
     }
 }

--- a/api/app/Jobs/User/DeleteUnverifiedUsers.php
+++ b/api/app/Jobs/User/DeleteUnverifiedUsers.php
@@ -7,28 +7,33 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 
+/**
+ * Class DeleteUnverifiedUsers
+ * @package App\Jobs\User
+ */
 class DeleteUnverifiedUsers implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Execute the job.
      *
+     * @param  \App\Models\User $users
      * @return void
      */
-    public function handle()
+    public function handle(\App\Models\User $users)
     {
-        //
+        $unverifiedUsers = $users
+            ->withTrashed()
+            ->where('email_verified_at', '=', null)
+            ->where('created_at', '<', Carbon::now()->subDays(deleteUnverifiedUsers()))
+            ->forceDelete();
+
+        if ($unverifiedUsers) {
+            Log::info("[Job] Deleted '{$unverifiedUsers}' unverified users permanently.");
+        }
     }
 }

--- a/api/app/Mail/DeleteUser.php
+++ b/api/app/Mail/DeleteUser.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Class DeleteUser
@@ -61,6 +62,8 @@ class DeleteUser extends Mailable implements ShouldQueue
     {
         $lang = $this->locale ?? App::getLocale();
         $subject = __('mails.subject_delete_user');
+
+        Log::info("[Mail] 'App\Mail\DeleteUser' has been sent to '{$this->email}'");
 
         return $this->view('mails.user.delete')
             ->text('mails.user.delete_plain')


### PR DESCRIPTION
This commit adds two new jobs. The DeleteInactiveUsers job, is going to delete users that have been inactive for a given period of time. The job is checking the updated_at field to determine if an user is active or not. Inactive users will be soft deleted. Once a user as been soft deleted the ClearUsers job is going to deleted all users that haven't recovered their accounts after they have been marked as deleted.

The DeleteUnverifiedUsers job did exist already, but was part of the ClearUsers job. It has been moved out for a better separation.